### PR TITLE
Fixed "device_name" of venus

### DIFF
--- a/venus.json
+++ b/venus.json
@@ -8,7 +8,7 @@
       "size":2134053693,
       "url": "https://master.dl.sourceforge.net/project/superioros/venus/gapps/SuperiorOS-Thirteen-venus-GAPPS-RELEASE-20230313-1033.zip",
       "version": "Thirteen",
-      "device_name": "venus",
+      "device_name": "Xiaomi Mi 11",
       "maintainer": "Alan Lin"
     }
   ]


### PR DESCRIPTION
Changed the "device_name" of venus (Xiaomi Mi 11) to follow the convention. As for most devices that property is their model name (including [venus in the official_devices repo](https://github.com/SuperiorOS-Devices/official_devices/blob/thirteen/venus.json)) this inconsistency causes some parsers to fail. This PR fixes the problem.